### PR TITLE
FIX (prop-types): add node as optionanal to SegmentedButton's label

### DIFF
--- a/app/src/components/base/SegmentedButton.js
+++ b/app/src/components/base/SegmentedButton.js
@@ -35,9 +35,9 @@ SegmentedButton.propTypes = {
   sections: PropTypes.arrayOf(
     PropTypes.shape({
       id: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
-      label: PropTypes.string,
+      label: PropTypes.oneOfType([PropTypes.node, PropTypes.string]),
       className: PropTypes.string,
-      disabled: PropTypes.boolean
+      disabled: PropTypes.bool
     })
   ),
   selected: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),


### PR DESCRIPTION
Why?: 
Because I health app we use label to render element with icon and t is getting warning