### PR TITLE
DAT-46185: App Components - Fix toast/snackbar overlapping

### DIFF
--- a/app/src/App.js
+++ b/app/src/App.js
@@ -10,7 +10,8 @@ import { withRouter } from 'react-router';
 import CustomColor from './generators/CustomColor';
 
 // notifications
-import { ToastsProvider, lightTheme, darkTheme } from './components/index';
+import { lightTheme, darkTheme } from './components/index';
+import { NotificationsProvider } from './components/base/Notifications';
 
 // docs
 import Home from './docs/Home.doc';
@@ -169,7 +170,7 @@ class App extends Component {
     return (
       <Router>
         <ThemeProvider theme={theme}>
-          <ToastsProvider>
+          <NotificationsProvider>
             <CustomColor
               open={colorsOpen}
               theme={theme}
@@ -235,7 +236,7 @@ class App extends Component {
                 <Route exact path="/drag-drop" component={DragDrop} />
               </Content>
             </Container>
-          </ToastsProvider>
+          </NotificationsProvider>
         </ThemeProvider>
       </Router>
     );

--- a/app/src/components/base/Notifications/Snackbars.js
+++ b/app/src/components/base/Notifications/Snackbars.js
@@ -1,0 +1,71 @@
+import React, { useContext, useMemo, Fragment } from 'react';
+
+// Styles
+import {
+  Meta,
+  SnackbarTitle,
+  CloseIcon,
+  Snackbar
+} from './notifications.styles';
+
+// Utils
+import {
+  useNotifications,
+  useNotification,
+  getIcon
+} from './notifications.utils';
+
+const Context = React.createContext();
+
+const SnackbarItem = ({
+  id,
+  title,
+  type,
+  top = 0,
+  speed = 150,
+  className,
+  index,
+  clear
+}) => {
+  const { isLeaving } = useNotification(id, clear);
+
+  return (
+    <Snackbar
+      top={top + index * 40}
+      speed={speed}
+      leaving={isLeaving}
+      className={className}
+    >
+      <CloseIcon onClick={() => clear(id)} />
+      {getIcon(type)}
+
+      <Meta>
+        <SnackbarTitle>{title}</SnackbarTitle>
+      </Meta>
+    </Snackbar>
+  );
+};
+
+export const SnackbarProvider = ({ children, throttle = 200 }) => {
+  const { list, clear, addNotification } = useNotifications({ throttle });
+
+  const snackbars = useMemo(
+    () =>
+      list.map((config, index) => (
+        <SnackbarItem key={config.id} {...config} index={index} clear={clear} />
+      )),
+    [clear, list]
+  );
+
+  return (
+    <Context.Provider value={{ addSnackbar: addNotification }}>
+      <Fragment>
+        {snackbars}
+
+        {children}
+      </Fragment>
+    </Context.Provider>
+  );
+};
+
+export const useSnackbar = () => useContext(Context);

--- a/app/src/components/base/Notifications/Toasts.js
+++ b/app/src/components/base/Notifications/Toasts.js
@@ -1,0 +1,59 @@
+import React, { useMemo, Fragment, useContext } from 'react';
+
+// Styles
+import {
+  Meta,
+  Subtitle,
+  Title,
+  CloseIcon,
+  Toast
+} from './notifications.styles';
+
+// Utils
+import {
+  useNotifications,
+  useNotification,
+  getIcon
+} from './notifications.utils';
+
+const Context = React.createContext();
+
+const ToastItem = ({ id, title, subtitle, type, index, clear }) => {
+  const { isLeaving } = useNotification(id, clear);
+
+  return (
+    <Toast key={`notif-${id}`} top={index * 80} leaving={isLeaving}>
+      <CloseIcon onClick={() => clear(id)} />
+      {getIcon(type)}
+
+      <Meta>
+        <Title>{title}</Title>
+        <Subtitle>{subtitle}</Subtitle>
+      </Meta>
+    </Toast>
+  );
+};
+
+export const ToastsProvider = ({ children }) => {
+  const { list, clear, addNotification } = useNotifications();
+
+  const toasts = useMemo(
+    () =>
+      list.map((config, index) => (
+        <ToastItem key={config.id} {...config} index={index} clear={clear} />
+      )),
+    [clear, list]
+  );
+
+  return (
+    <Context.Provider value={{ addToast: addNotification }}>
+      <Fragment>
+        {toasts}
+
+        {children}
+      </Fragment>
+    </Context.Provider>
+  );
+};
+
+export const useToast = () => useContext(Context);

--- a/app/src/components/base/Notifications/index.js
+++ b/app/src/components/base/Notifications/index.js
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import { ToastsProvider, useToast } from './Toasts';
+import { SnackbarProvider, useSnackbar } from './Snackbars';
+
+const NotificationsProvider = ({ children }) => (
+  <ToastsProvider>
+    <SnackbarProvider>{children}</SnackbarProvider>
+  </ToastsProvider>
+);
+
+export { NotificationsProvider, useToast, useSnackbar };

--- a/app/src/components/base/Notifications/notifications.styles.js
+++ b/app/src/components/base/Notifications/notifications.styles.js
@@ -1,0 +1,176 @@
+import styled, { css, keyframes } from 'styled-components';
+
+import InfoIcon from '../../icons/InfoLine.icon';
+import WarningIcon from '../../icons/WarningLine.icon';
+import SuccessIcon from '../../icons/SuccessLine.icon';
+
+export const fadeSlideInFromTop = keyframes`
+    from {
+      opacity: 0;
+      transform: translate3d(-50%, -50%, 0);
+    }
+    to {
+      opacity: 1;
+      transform: translate3d(-50%, 0, 0);
+    }
+`;
+
+export const fadeSlideOutToTop = keyframes`
+    from {
+      opacity: 1;
+      transform: translate3d(-50%, 0, 0);
+    }
+    to {
+      opacity: 0;
+      transform: translate3d(-50%, -50%, 0);
+    }
+`;
+
+export const Toast = styled.div`
+  position: fixed;
+  width: 360px;
+  height: 70px;
+  background: ${({ theme }) => theme.p0};
+  border-radius: 4px;
+  box-shadow: 0 5px 20px rgba(0, 0, 0, 0.2);
+  box-sizing: border-box;
+  padding: 12px;
+  transition: all 1000ms;
+  right: 20px;
+  top: ${({ top }) => `${20 + top}px`};
+  z-index: 999;
+  ${({ theme, leaving }) =>
+    leaving ? theme.animation.fadeRightExit : theme.animation.fadeLeft};
+  display: flex;
+`;
+
+export const Meta = styled.div`
+  flex-direction: column;
+  display: flex;
+`;
+
+export const Title = styled.div`
+  ${({ theme }) => theme.text.pBold};
+  height: 22px;
+  display: flex;
+  align-items: center;
+`;
+
+export const Subtitle = styled.div`
+  ${({ theme }) => theme.text.smNote};
+  margin: 0 30px 0 0;
+`;
+
+export const StyledInfoIcon = styled(InfoIcon)`
+  width: 22px;
+  height: 22px;
+  margin-right: 4px;
+  margin-bottom: 1px;
+`;
+
+export const StyledAlertIcon = styled(InfoIcon)`
+  width: 22px;
+  height: 22px;
+  margin-right: 4px;
+`;
+
+export const StyledWarningIcon = styled(WarningIcon)`
+  width: 22px;
+  height: 22px;
+  margin-right: 4px;
+`;
+
+export const StyledSuccessIcon = styled(SuccessIcon)`
+  width: 22px;
+  height: 22px;
+  margin-right: 4px;
+`;
+
+export const CloseIcon = styled.div`
+  position: absolute;
+  top: 15px;
+  right: 15px;
+  cursor: pointer;
+
+  width: 12px;
+  height: 12px;
+  overflow: hidden;
+
+  &:hover {
+    &::before,
+    &::after {
+      background: ${({ theme }) => theme.p500};
+    }
+  }
+
+  &::before,
+  &::after {
+    content: '';
+    position: absolute;
+    height: 2px;
+    width: 100%;
+    top: 50%;
+    left: 0;
+    margin-top: -1px;
+    background: ${({ theme }) => theme.p300};
+  }
+
+  &::before {
+    transform: rotate(45deg);
+  }
+
+  &::after {
+    transform: rotate(-45deg);
+  }
+
+  &::before,
+  &::after {
+    height: 1px;
+  }
+`;
+
+export const Snackbar = styled.div`
+  position: fixed;
+  left: 50%;
+  ${({ leaving, speed }) =>
+    css`
+      animation: ${leaving ? fadeSlideOutToTop : fadeSlideInFromTop} ${speed}ms
+        ease-out both;
+    `};
+  box-sizing: border-box;
+  padding: 5px;
+  transition: all 1000ms;
+  top: ${({ top }) => `${20 + top}px`};
+  z-index: 999;
+  display: flex;
+  align-items: center;
+  height: 30px;
+  border-radius: 2px;
+  box-shadow: 0 2px 14px 0 rgba(0, 0, 0, 0.2);
+  background-color: ${({ theme }) => theme.p400};
+
+  ${CloseIcon} {
+    top: 10px;
+    right: 10px;
+    color: #fff;
+
+    &::before,
+    &::after {
+      color: #fff;
+    }
+
+    &:hover {
+      &::before,
+      &::after {
+        color: #fff;
+      }
+    }
+  }
+`;
+
+export const SnackbarTitle = styled.div`
+  font-size: 12px;
+  font-weight: 400;
+  color: ${({ theme }) => theme.p0};
+  margin: 0 30px 0 0;
+`;

--- a/app/src/components/base/Notifications/notifications.utils.js
+++ b/app/src/components/base/Notifications/notifications.utils.js
@@ -1,0 +1,83 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { throttle as fpThrottle } from 'lodash/fp';
+
+import {
+  StyledInfoIcon,
+  StyledSuccessIcon,
+  StyledWarningIcon,
+  StyledAlertIcon
+} from './notifications.styles';
+
+export const useNotifications = ({ throttle = 0 } = {}) => {
+  const [list, setList] = useState([]);
+
+  const clear = useCallback(
+    id =>
+      setList(prevState =>
+        prevState.filter(notification => notification.id !== id)
+      ),
+    [setList]
+  );
+
+  const addNotification = useCallback(notification => {
+    const id = Math.random();
+
+    setList(prevState => [...prevState, { id, ...notification }]);
+  }, []);
+
+  return {
+    list,
+    setList,
+    addNotification: fpThrottle(throttle, addNotification),
+    clear
+  };
+};
+
+export const useNotification = (id, clear) => {
+  const [isLeaving, setIsLeaving] = useState(false);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => {
+      setIsLeaving(true);
+    }, 5000);
+
+    return () => {
+      clearTimeout(timeout);
+    };
+  }, []);
+
+  useEffect(() => {
+    if (isLeaving) {
+      const timeout = setTimeout(() => {
+        clear(id);
+      }, 500);
+
+      return () => {
+        clearTimeout(timeout);
+      };
+    }
+  }, [clear, id, isLeaving]);
+
+  return {
+    isLeaving
+  };
+};
+
+export const getIcon = type => {
+  switch (type) {
+    case 'info':
+      return <StyledInfoIcon />;
+
+    case 'alert':
+      return <StyledAlertIcon />;
+
+    case 'success':
+      return <StyledSuccessIcon />;
+
+    case 'warning':
+      return <StyledWarningIcon />;
+
+    default:
+      return null;
+  }
+};

--- a/app/src/components/index.js
+++ b/app/src/components/index.js
@@ -39,6 +39,11 @@ export {
   withSnackbar,
   default as ToastsProvider
 } from './base/Toasts';
+export {
+  useSnackbar,
+  useToast,
+  NotificationsProvider
+} from './base/Notifications';
 export { default as Toggle } from './base/Toggle';
 export { default as Tooltip } from './base/Tooltip';
 export { default as Widget } from './base/Widget';

--- a/app/src/docs/Snippet.js
+++ b/app/src/docs/Snippet.js
@@ -1,19 +1,26 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import Highlight from 'react-highlight.js';
 import styled from 'styled-components';
 import { ReactComponent as Copy } from './assets/copy.svg';
-import { withToast } from '../components/base/Toasts';
 import { CopyToClipboard } from 'react-copy-to-clipboard';
 
+import { useToast } from '../components/base/Notifications/Toasts';
+
 const Snippet = props => {
+  const { addToast } = useToast();
   const { snippet } = props;
+
+  const highlight = useMemo(
+    () => <Highlight language="javascript">{snippet}</Highlight>,
+    [snippet]
+  );
 
   return (
     <Relative>
       <CopyToClipboard
         text={snippet}
         onCopy={() =>
-          props.addToast({
+          addToast({
             title: 'Copied successfully!',
             subtitle: 'Snippet copies to clipboard',
             type: 'success'
@@ -24,12 +31,13 @@ const Snippet = props => {
           <StyledCopy />
         </CopyBtn>
       </CopyToClipboard>
-      <Highlight language="javascript">{snippet}</Highlight>
+
+      {highlight}
     </Relative>
   );
 };
 
-export default withToast(Snippet);
+export default Snippet;
 
 const Relative = styled.div`
   position: relative;

--- a/app/src/docs/Toast.doc.js
+++ b/app/src/docs/Toast.doc.js
@@ -9,7 +9,6 @@ import { useSnackbar } from '../components/base/Notifications/Snackbars';
 import Snippet from './Snippet';
 
 const snippet = `
-
 import { NotificationsProvider, useToast, useSnackbar } from '@datorama/app-components';
 
 const App = () => (
@@ -25,7 +24,6 @@ const NestedComp = () => {
 
 // toast object. types - info (default), success, warning and alert
 // { title: '',  subtitle: '', type: 'alert', timeout: 3000 }
-
 // toast object. types - info (default), success, warning and alert
 // { title: '', type: 'alert', timeout: 3000, top: 0 }
 `;

--- a/app/src/docs/Toast.doc.js
+++ b/app/src/docs/Toast.doc.js
@@ -3,45 +3,37 @@ import styled, { withTheme } from 'styled-components';
 
 // components
 import Base from './Base';
-import { Row, Col, withToast, Button, withSnackbar } from '../components/index';
+import { Row, Col, Button } from '../components/index';
+import { useToast } from '../components/base/Notifications/Toasts';
+import { useSnackbar } from '../components/base/Notifications/Snackbars';
 import Snippet from './Snippet';
 
 const snippet = `
 
-import { ToastsProvider, withToast } from '@datorama/app-components';
+import { NotificationsProvider, useToast, useSnackbar } from '@datorama/app-components';
 
 const App = () => (
-  <ToastsProvider>
+  <NotificationsProvider>
     ... wrap your entire app
-  </ToastsProvider>
+  </NotificationsProvider>
 );
 
-const NestedComp = ({ addToast }) => ();
-
-export const withToast(NestedComp);
+const NestedComp = () => {
+    const { addToast } = useToast();
+    const { addSnackbar } = useSnackbar(); 
+};
 
 // toast object. types - info (default), success, warning and alert
 // { title: '',  subtitle: '', type: 'alert', timeout: 3000 }
-`;
-
-const snippetSnackbar = `
-import { ToastsProvider, withSnackbar } from '@datorama/app-components';
-
-const App = () => (
-  <ToastsProvider>
-    ... wrap your entire app
-  </ToastsProvider>
-);
-
-const NestedComp = ({ addSnackbar }) => ();
-
-export const withSnackbar(NestedComp);
 
 // toast object. types - info (default), success, warning and alert
 // { title: '', type: 'alert', timeout: 3000, top: 0 }
 `;
 
-const ToastDoc = props => {
+const ToastDoc = () => {
+  const { addToast } = useToast();
+  const { addSnackbar } = useSnackbar();
+
   const title = 'toasts';
   const description = 'toasts & snackbars';
 
@@ -56,40 +48,36 @@ const ToastDoc = props => {
 
   return (
     <Base title={title} description={description}>
-      <Row>
-        <Col>
-          <SectionTitle>Toasts</SectionTitle>
-        </Col>
-      </Row>
-
       <Row align="stretch">
         <Col>
           <Snippet snippet={snippet} />
         </Col>
       </Row>
+
+      <Row>
+        <Col>
+          <SectionTitle>Toasts</SectionTitle>
+        </Col>
+      </Row>
       <Row>
         <Col>
           <Box>
-            <StyledButton
-              onClick={() => props.addToast({ ...notif, type: 'info' })}
-            >
+            <StyledButton onClick={() => addToast({ ...notif, type: 'info' })}>
               Info toast
             </StyledButton>
 
-            <StyledButton
-              onClick={() => props.addToast({ ...notif, type: 'alert' })}
-            >
+            <StyledButton onClick={() => addToast({ ...notif, type: 'alert' })}>
               Alert toast
             </StyledButton>
 
             <StyledButton
-              onClick={() => props.addToast({ ...notif, type: 'success' })}
+              onClick={() => addToast({ ...notif, type: 'success' })}
             >
               Success toast
             </StyledButton>
 
             <StyledButton
-              onClick={() => props.addToast({ ...notif, type: 'warning' })}
+              onClick={() => addToast({ ...notif, type: 'warning' })}
             >
               Warning toast
             </StyledButton>
@@ -102,38 +90,26 @@ const ToastDoc = props => {
           <SectionTitle>Snackbar</SectionTitle>
         </Col>
       </Row>
-
-      <Row align="stretch">
-        <Col>
-          <Snippet snippet={snippetSnackbar} />
-        </Col>
-      </Row>
       <Row>
         <Col>
           <Box>
             <StyledButton
-              onClick={() => props.addSnackbar({ ...snackNotif, type: 'info' })}
+              onClick={() => addSnackbar({ ...snackNotif, type: 'info' })}
             >
               Info Snackbar
             </StyledButton>
             <StyledButton
-              onClick={() =>
-                props.addSnackbar({ ...snackNotif, type: 'alert' })
-              }
+              onClick={() => addSnackbar({ ...snackNotif, type: 'alert' })}
             >
               Alert Snackbar
             </StyledButton>
             <StyledButton
-              onClick={() =>
-                props.addSnackbar({ ...snackNotif, type: 'success' })
-              }
+              onClick={() => addSnackbar({ ...snackNotif, type: 'success' })}
             >
               Success Snackbar
             </StyledButton>
             <StyledButton
-              onClick={() =>
-                props.addSnackbar({ ...snackNotif, type: 'warning' })
-              }
+              onClick={() => addSnackbar({ ...snackNotif, type: 'warning' })}
             >
               Warning Snackbar
             </StyledButton>
@@ -144,7 +120,7 @@ const ToastDoc = props => {
   );
 };
 
-export default withToast(withSnackbar(withTheme(ToastDoc)));
+export default withTheme(ToastDoc);
 
 const Box = styled.div`
   width: 100%;


### PR DESCRIPTION
- Rewrite toasts & snackbars logic
- Divide their providers
- Put them under one NotificationsProvider
- Update docs

I left the 'legacy' toast, so that any app using them won't be effected