### PR TITLE
DAT-71390 - add rowIndex prop to cellRenderer in Grid component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@datorama/app-components",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datorama/app-components",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "Datorama React components library",
   "homepage": "https://app-components.herokuapp.com",
   "engines": {

--- a/src/components/Grid/Body.tsx
+++ b/src/components/Grid/Body.tsx
@@ -62,6 +62,7 @@ const rowRenderer = (props: RowRendererProps) => {
           >
             {cellRenderer ? (
               cellRenderer({
+                rowIndex: index,
                 key: header.dataKey,
                 value: get(header.dataKey, data[index]),
               })

--- a/src/components/Grid/Grid.types.ts
+++ b/src/components/Grid/Grid.types.ts
@@ -33,9 +33,11 @@ export type RowRenderer = (params: RowRendererProps) => ReactElement | null;
 export type CellRenderer = ({
   key,
   value,
+  rowIndex,
 }: {
   key: string | number;
   value: string | number;
+  rowIndex: number;
 }) => ReactElement | null;
 
 export type HeaderCellRenderer = ({

--- a/src/stories/0_Notes.stories.mdx
+++ b/src/stories/0_Notes.stories.mdx
@@ -15,6 +15,10 @@ The following components are pending deprecation and will be removed in next rel
 
 <br /><br />
 
+## 1.3.5
+
+Added rowIndex prop to the cellRenderer function in the Grid component.
+
 ## 1.3.4
 
 Fixed BasicLine tooltip positioning.


### PR DESCRIPTION
## Description
add rowIndex prop to cellRenderer in Grid componen
## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Are you adding a new package?
- [ ] yes
- [x] no
