### PR TITLE
feature/DAT-72870 - global styles custom color prefix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@datorama/app-components",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datorama/app-components",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Datorama React components library",
   "homepage": "https://app-components.herokuapp.com",
   "engines": {

--- a/src/components/GlobalStyles/GlobalStyles.tsx
+++ b/src/components/GlobalStyles/GlobalStyles.tsx
@@ -32,7 +32,12 @@ const generateSvgMixins = (
   theme: Record<string, any>,
   customColorPrefixes: string[]
 ) => {
-  const colorPrefixes = ['a', 's', 'p', ...customColorPrefixes];
+  const colorPrefixes = [
+    'a',
+    's',
+    'p',
+    ...customColorPrefixes.map((prefix) => `custom-${prefix}`),
+  ];
   let result: string[][] = [];
 
   for (const colorPrefix of colorPrefixes) {
@@ -57,6 +62,13 @@ export function generateGlobalStyles(
   theme: Record<string, any>,
   customColorPrefixes: string[]
 ): GlobalStyleComponent<any, DefaultTheme> {
+  console.error(
+    generateSvgMixins(
+      ['fill', 'stroke', 'stop-color'],
+      theme,
+      customColorPrefixes
+    )
+  );
   const globalStyles = createGlobalStyle`
     ${generateSvgMixins(
       ['fill', 'stroke', 'stop-color'],

--- a/src/stories/5_GlobalStyles.stories.mdx
+++ b/src/stories/5_GlobalStyles.stories.mdx
@@ -19,7 +19,7 @@ with:
 Now, if the first hue color is changed in the branding process, the theme palette will be regenerated, and the svg's polygon fill color will change accordingly.
 
 There are similar classes created for all color stops for accent (first hue), secondary (second hue), primary (neutral), and custom colors. 
-For first (a prefix), secondary (s prefix), and custom colors (e.g. c1, c2... based on the prefixes provided in the AppTheme) the color stops generated in the palette are: 100, 200, 300, 350, 400, 500, 600, 700, 800.
+For first (a prefix), secondary (s prefix), and custom colors (e.g. custom-c1, custom-c2... based on the c1, c2... prefixes provided in the AppTheme) the color stops generated in the palette are: 100, 200, 300, 350, 400, 500, 600, 700, 800.
 For neutral (p prefix) the color stops are: 0 (white), 50, 100, 200, 300, 400, 500, 600, 700 (see examples in the [colors page](/story/colors--page?path=/story/colors--page)).
 
 The structure of each generated class is: 


### PR DESCRIPTION
## Description

Added 'custom' prefix to generated branding class names

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Are you adding a new package?
- [ ] yes
- [x] no
