### PR TITLE
DAT-72425 - create a generic CSS grid containers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@datorama/app-components",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@datorama/app-components",
-      "version": "1.3.7",
+      "version": "1.6.0",
       "license": "MIT",
       "dependencies": {
         "d3-scale": "^3.2.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datorama/app-components",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Datorama React components library",
   "homepage": "https://app-components.herokuapp.com",
   "engines": {

--- a/src/components/GridLayout/GridItem.tsx
+++ b/src/components/GridLayout/GridItem.tsx
@@ -1,0 +1,73 @@
+import React, { ReactNode } from 'react';
+import styled from 'styled-components';
+import { isObject } from 'lodash/fp';
+
+type SizeObject = {
+  sm?: string;
+  md?: string;
+  lg?: string;
+};
+
+type GridItemProps = {
+  row?: string | SizeObject;
+  column?: string | SizeObject;
+  justifySelf?: 'start' | 'end' | 'center' | 'stretch';
+  alignSelf?: 'start' | 'end' | 'center' | 'stretch';
+  sm?: number;
+  md?: number;
+};
+
+export interface Props extends GridItemProps {
+  children: ReactNode | ReactNode[];
+  className?: string;
+}
+
+export const GridItem = (props: Props) => {
+  const {
+    children,
+    className,
+    row,
+    column,
+    justifySelf,
+    alignSelf,
+    sm,
+    md,
+  } = props;
+
+  return (
+    <Container
+      className={className}
+      row={row}
+      column={column}
+      justifySelf={justifySelf}
+      alignSelf={alignSelf}
+      sm={sm}
+      md={md}
+    >
+      {children}
+    </Container>
+  );
+};
+
+GridItem.defaultProps = {
+  justifySelf: 'stretch',
+  alignSelf: 'stretch',
+};
+
+const Container = styled.div<GridItemProps>`
+  grid-row: ${({ row }) => (isObject(row) ? row.lg : row)};
+  grid-column: ${({ column }) => (isObject(column) ? column.lg : column)};
+
+  justify-self: ${({ justifySelf }) => justifySelf};
+  align-self: ${({ alignSelf }) => alignSelf};
+
+  @media only screen and (max-width: ${({ md }) => md}px) {
+    grid-row: ${({ row }) => (isObject(row) ? row.md : row)};
+    grid-column: ${({ column }) => (isObject(column) ? column.md : column)};
+  }
+
+  @media only screen and (max-width: ${({ sm }) => sm}px) {
+    grid-row: ${({ row }) => (isObject(row) ? row.sm : row)};
+    grid-column: ${({ column }) => (isObject(column) ? column.sm : column)};
+  }
+`;

--- a/src/components/GridLayout/GridItem.tsx
+++ b/src/components/GridLayout/GridItem.tsx
@@ -11,6 +11,7 @@ type SizeObject = {
 type GridItemProps = {
   row?: string | SizeObject;
   column?: string | SizeObject;
+  gridArea?: string | SizeObject;
   justifySelf?: 'start' | 'end' | 'center' | 'stretch';
   alignSelf?: 'start' | 'end' | 'center' | 'stretch';
   sm?: number;
@@ -28,6 +29,7 @@ export const GridItem = (props: Props) => {
     className,
     row,
     column,
+    gridArea,
     justifySelf,
     alignSelf,
     sm,
@@ -39,6 +41,7 @@ export const GridItem = (props: Props) => {
       className={className}
       row={row}
       column={column}
+      gridArea={gridArea}
       justifySelf={justifySelf}
       alignSelf={alignSelf}
       sm={sm}
@@ -57,6 +60,7 @@ GridItem.defaultProps = {
 const Container = styled.div<GridItemProps>`
   grid-row: ${({ row }) => (isObject(row) ? row.lg : row)};
   grid-column: ${({ column }) => (isObject(column) ? column.lg : column)};
+  grid-area: ${({ gridArea }) => (isObject(gridArea) ? gridArea.lg : gridArea)};
 
   justify-self: ${({ justifySelf }) => justifySelf};
   align-self: ${({ alignSelf }) => alignSelf};
@@ -64,10 +68,14 @@ const Container = styled.div<GridItemProps>`
   @media only screen and (max-width: ${({ md }) => md}px) {
     grid-row: ${({ row }) => (isObject(row) ? row.md : row)};
     grid-column: ${({ column }) => (isObject(column) ? column.md : column)};
+    grid-area: ${({ gridArea }) =>
+      isObject(gridArea) ? gridArea.md : gridArea};
   }
 
   @media only screen and (max-width: ${({ sm }) => sm}px) {
     grid-row: ${({ row }) => (isObject(row) ? row.sm : row)};
     grid-column: ${({ column }) => (isObject(column) ? column.sm : column)};
+    grid-area: ${({ gridArea }) =>
+      isObject(gridArea) ? gridArea.sm : gridArea};
   }
 `;

--- a/src/components/GridLayout/GridLayout.tsx
+++ b/src/components/GridLayout/GridLayout.tsx
@@ -1,0 +1,101 @@
+import React, { ReactNode, useMemo } from 'react';
+import styled from 'styled-components';
+
+type GridProps = {
+  gridGap?: number;
+  gridTemplateRows?: string;
+  justifyItems?: 'start' | 'end' | 'center' | 'stretch';
+  alignItems?: 'start' | 'end' | 'center' | 'stretch';
+  justifyContent?:
+    | 'start'
+    | 'end'
+    | 'center'
+    | 'stretch'
+    | 'space-around'
+    | 'space-between'
+    | 'space-evenly';
+  alignContent?:
+    | 'start'
+    | 'end'
+    | 'center'
+    | 'stretch'
+    | 'space-around'
+    | 'space-between'
+    | 'space-evenly';
+  gridAutoFlow?: 'row' | 'column' | 'dense';
+};
+
+export interface Props extends GridProps {
+  children: ReactNode | ReactNode[];
+  className?: string;
+  sm?: number;
+  md?: number;
+}
+
+export const GridLayout = (props: Props) => {
+  const {
+    children,
+    className,
+    gridGap,
+    gridTemplateRows,
+    justifyContent,
+    justifyItems,
+    alignContent,
+    alignItems,
+    gridAutoFlow,
+    sm,
+    md,
+  } = props;
+
+  const childrenWithProps = useMemo(
+    () =>
+      React.Children.map(children, (child) => {
+        if (React.isValidElement(child)) {
+          return React.cloneElement(child, { sm, md });
+        }
+
+        return child;
+      }),
+    [children, sm, md]
+  );
+
+  return (
+    <Container
+      className={className}
+      gridGap={gridGap}
+      gridTemplateRows={gridTemplateRows}
+      justifyContent={justifyContent}
+      justifyItems={justifyItems}
+      alignContent={alignContent}
+      alignItems={alignItems}
+      gridAutoFlow={gridAutoFlow}
+    >
+      {childrenWithProps}
+    </Container>
+  );
+};
+
+GridLayout.defaultProps = {
+  gridGap: 8,
+  justifyItems: 'stretch',
+  alignItems: 'stretch',
+  justifyContent: 'stretch',
+  alignContent: 'stretch',
+  sm: 1000,
+  md: 1400,
+};
+
+const Container = styled.div<GridProps>`
+  display: grid;
+  grid-gap: ${({ gridGap }) => `${gridGap}px`};
+
+  grid-template-columns: repeat(12, 1fr);
+  grid-template-rows: ${({ gridTemplateRows }) => gridTemplateRows};
+
+  justify-items: ${({ justifyItems }) => justifyItems};
+  align-items: ${({ alignItems }) => alignItems};
+
+  justify-content: ${({ justifyContent }) => justifyContent};
+  align-content: ${({ alignContent }) => alignContent};
+  grid-auto-flow: ${({ gridAutoFlow }) => gridAutoFlow};
+`;

--- a/src/components/GridLayout/GridLayout.tsx
+++ b/src/components/GridLayout/GridLayout.tsx
@@ -4,6 +4,8 @@ import styled from 'styled-components';
 type GridProps = {
   gridGap?: number;
   gridTemplateRows?: string;
+  gridTemplateColumns?: string;
+  gridTemplateAreas?: string;
   justifyItems?: 'start' | 'end' | 'center' | 'stretch';
   alignItems?: 'start' | 'end' | 'center' | 'stretch';
   justifyContent?:
@@ -38,6 +40,8 @@ export const GridLayout = (props: Props) => {
     className,
     gridGap,
     gridTemplateRows,
+    gridTemplateColumns,
+    gridTemplateAreas,
     justifyContent,
     justifyItems,
     alignContent,
@@ -64,6 +68,8 @@ export const GridLayout = (props: Props) => {
       className={className}
       gridGap={gridGap}
       gridTemplateRows={gridTemplateRows}
+      gridTemplateColumns={gridTemplateColumns}
+      gridTemplateAreas={gridTemplateAreas}
       justifyContent={justifyContent}
       justifyItems={justifyItems}
       alignContent={alignContent}
@@ -89,8 +95,10 @@ const Container = styled.div<GridProps>`
   display: grid;
   grid-gap: ${({ gridGap }) => `${gridGap}px`};
 
-  grid-template-columns: repeat(12, 1fr);
+  grid-template-columns: ${({ gridTemplateColumns }) =>
+    gridTemplateColumns || 'repeat(12, 1fr)'};
   grid-template-rows: ${({ gridTemplateRows }) => gridTemplateRows};
+  grid-template-areas: ${({ gridTemplateAreas }) => gridTemplateAreas};
 
   justify-items: ${({ justifyItems }) => justifyItems};
   align-items: ${({ alignItems }) => alignItems};

--- a/src/index.ts
+++ b/src/index.ts
@@ -76,6 +76,8 @@ export { SnailChart } from './components/SnailChart';
 export { GoalsChart } from './components/GoalsChart/GoalsChart';
 export { Gauge } from './components/Gauge';
 export { Grid } from './components/Grid/Grid';
+export { GridLayout } from './components/GridLayout/GridLayout';
+export { GridItem } from './components/GridLayout/GridItem';
 
 // Pending Deprecation
 export { IllustratedMessage } from './components/IllustratedMessage/IllustratedMessage';

--- a/src/stories/0_Notes.stories.mdx
+++ b/src/stories/0_Notes.stories.mdx
@@ -15,6 +15,9 @@ The following components are pending deprecation and will be removed in next rel
 
 <br /><br />
 
+## 1.6.0
+Added a new Grid layout containers.
+
 ## 1.5.0
 Added tooltips capability to segmented button.
 

--- a/src/stories/4_Layout.stories.mdx
+++ b/src/stories/4_Layout.stories.mdx
@@ -1,9 +1,9 @@
 import { Meta, Story, Canvas } from '@storybook/addon-docs/blocks';
 import { Row, Col, Container } from '../constants/layout.constants';
 
-<Meta title="Flex-box Layout" />
+<Meta title="Flex-box Grid" />
 
-# Flex-box Layout
+# Flex-box GridLayout
 
 A 12 column grid layout using flex-box
 <br /><br />

--- a/src/stories/Layout.stories.tsx
+++ b/src/stories/Layout.stories.tsx
@@ -1,0 +1,78 @@
+import React from 'react';
+import styled from 'styled-components';
+
+import { GridLayout } from '../components/GridLayout/GridLayout';
+import { GridItem } from '../components/GridLayout/GridItem';
+
+export default {
+  title: 'core/Grid Layout',
+  component: GridLayout,
+  subcomponents: {
+    GridItem,
+  },
+  argTypes: {},
+};
+
+export const Primary = (args) => (
+  <StyledLayout {...args}>
+    <StyledLayoutItem>1</StyledLayoutItem>
+    <StyledLayoutItem>2</StyledLayoutItem>
+    <StyledLayoutItem>3</StyledLayoutItem>
+    <StyledLayoutItem>4</StyledLayoutItem>
+    <StyledLayoutItem>5</StyledLayoutItem>
+    <StyledLayoutItem>6</StyledLayoutItem>
+    <StyledLayoutItem>7</StyledLayoutItem>
+    <StyledLayoutItem>8</StyledLayoutItem>
+    <StyledLayoutItem>9</StyledLayoutItem>
+    <StyledLayoutItem>10</StyledLayoutItem>
+    <StyledLayoutItem>11</StyledLayoutItem>
+    <StyledLayoutItem>12</StyledLayoutItem>
+  </StyledLayout>
+);
+
+export const Advanced = (args) => (
+  <StyledLayout {...args}>
+    <StyledLayoutItem column={{ sm: 'span 12', md: 'span 6', lg: 'span 1' }}>
+      Logo
+    </StyledLayoutItem>
+    <StyledLayoutItem column={{ sm: 'span 12', md: 'span 6', lg: 'span 11' }}>
+      Navigation
+    </StyledLayoutItem>
+
+    <StyledLayoutItem column="span 12">Hero</StyledLayoutItem>
+
+    <StyledLayoutItem column={{ md: 'span 12', lg: 'span 4' }}>
+      Third
+    </StyledLayoutItem>
+    <StyledLayoutItem column={{ md: 'span 12', lg: 'span 4' }}>
+      Third
+    </StyledLayoutItem>
+    <StyledLayoutItem column={{ md: 'span 12', lg: 'span 4' }}>
+      Third
+    </StyledLayoutItem>
+
+    <StyledLayoutItem column={{ md: 'span 12', lg: 'span 6' }}>
+      Sidebar
+    </StyledLayoutItem>
+    <StyledLayoutItem column={{ md: 'span 12', lg: '7 / 13' }}>
+      Half
+    </StyledLayoutItem>
+    <StyledLayoutItem column={{ md: 'span 12', lg: '7 / 13' }}>
+      Half
+    </StyledLayoutItem>
+  </StyledLayout>
+);
+
+const StyledLayout = styled(GridLayout)`
+  background: ${({ theme }) => theme.g100};
+`;
+
+const StyledLayoutItem = styled(GridItem)`
+  background: ${({ theme }) => theme.a300};
+  ${({ theme }) => theme.text.smBold};
+  color: ${({ theme }) => theme.p0};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 40px;
+`;


### PR DESCRIPTION
## Description
Containers for CSS grid without loosing all of the features we get.

This is a 12 columns grid as agreed with the design team.

Everything is customized and aligned to the original CSS grid syntax.

I added the option to pass rows and columns as an object (or a string) of screen sizes - 
for example - 
for small screens - 12 columns.
for medium screens - 6 columns.
for large screens - 2 columns.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Are you adding a new package?
- [ ] yes
- [x] no
