### PR TITLE
DAT-74348 me run break down search funny behaviour

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@datorama/app-components",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@datorama/app-components",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datorama/app-components",
-  "version": "1.9.6",
+  "version": "1.9.7",
   "description": "Datorama React components library",
   "homepage": "https://app-components.herokuapp.com",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datorama/app-components",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Datorama React components library",
   "homepage": "https://app-components.herokuapp.com",
   "engines": {

--- a/src/components/Grid/Grid.tsx
+++ b/src/components/Grid/Grid.tsx
@@ -43,6 +43,7 @@ export interface Props {
   isBottomLoaderActive?: boolean;
   onSort?: (params: SortParams) => void;
   isResizable?: boolean;
+  extendedSearchHeaders?: string[];
 }
 
 const createNewSearch = () => {
@@ -78,6 +79,7 @@ export const Grid = (props: Props) => {
     isBottomLoaderActive,
     onSort,
     isResizable,
+    extendedSearchHeaders,
   } = props;
   const [scroll, setScroll] = useState({ scrollTop: 0 });
   const [sortData, setSortData] = useState<SortDataType>({});
@@ -94,8 +96,15 @@ export const Grid = (props: Props) => {
   useEffect(() => {
     // set search indexes
     if (isActionsActive) {
-      for (let i = 0; i < headers.length; i++) {
-        search.addIndex(get('dataKey', headers[i]));
+      const searchHeaders = [
+        ...headers,
+        ...(extendedSearchHeaders?.map((searchHeader) => ({
+          dataKey: searchHeader,
+        })) || []),
+      ];
+
+      for (let i = 0; i < searchHeaders.length; i++) {
+        search.addIndex(get('dataKey', searchHeaders[i]));
       }
     }
 

--- a/src/stories/0_Notes.stories.mdx
+++ b/src/stories/0_Notes.stories.mdx
@@ -15,6 +15,9 @@ The following components are pending deprecation and will be removed in next rel
 
 <br /><br />
 
+## 1.10.1
+Allow the Grid component consumer to pass additional data-columns that will only be searched (and not displayed in the table). This way, the user will can get results for formatted-data, etc.
+
 ## 1.10.0
 Add `onRowClick` prop to the `Grid` component
 


### PR DESCRIPTION
## Description
Allow the Grid component consumer to pass additional data-columns that will only be searched (and not displayed in the table). This way, the user will can get results for formatted-data, etc.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Are you adding a new package?
- [ ] yes
- [x] no
