### PR TITLE
Fix | DAT-75721: Add missing export of `useUploadFile`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@datorama/app-components",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datorama/app-components",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "Datorama React components library",
   "homepage": "https://app-components.herokuapp.com",
   "engines": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -82,7 +82,10 @@ export { GridItem } from './components/GridLayout/GridItem';
 export { Popover } from './components/Popover';
 
 // Provider
-export { UploadFileProvider } from './components/UploadFile/UploadFileProvider';
+export {
+  UploadFileProvider,
+  useUploadFile,
+} from './components/UploadFile/UploadFileProvider';
 
 // Hooks
 export { useConfirmationModal } from './hooks/confirmation-modal.hooks';

--- a/src/stories/0_Notes.stories.mdx
+++ b/src/stories/0_Notes.stories.mdx
@@ -15,6 +15,9 @@ The following components are pending deprecation and will be removed in next rel
 
 <br /><br />
 
+## 1.15.1
+Export [useUploadFile](?path=/docs/utils-upload-file--page) util hook together with UploadFileProvider
+
 ## 1.15.0
 Add [Upload File utility component](?path=/docs/utils-upload-file--page)
 

--- a/src/stories/UploadFile.stories.mdx
+++ b/src/stories/UploadFile.stories.mdx
@@ -81,7 +81,7 @@ const InnerComponent = () => {
 
 ```typescript jsx
 import sdk from '@datorama/sdk';
-import Papaparse from 'papaparse';
+import Papa from 'papaparse';
 
 export const downloadCsvFile = ({
   content,


### PR DESCRIPTION
## Description

Add missing export of `useUploadFIle` util hook

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Are you adding a new package?
- [ ] yes
- [x] no
