### PR TITLE
DAT-79196 multi select with 2 groups crashes when unselecting all

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@datorama/app-components",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@datorama/app-components",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Datorama React components library",
   "homepage": "https://app-components.herokuapp.com",
   "engines": {

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -368,24 +368,36 @@ export class Select extends React.Component {
     const { options } = this.props;
     const { localValues } = this.state;
     const optionsSize = getOptionsSize(options);
-    const isFilteringUsed = this.filteredOptions.length < optionsSize;
+    const optionsHasGroups = hasGroups(options);
+    const isFilteringUsed = optionsHasGroups
+      ? getAllOptions(this.filteredOptions).length < optionsSize
+      : this.filteredOptions.length < optionsSize;
 
     let result = [];
 
     if (isDeselect) {
       if (isFilteringUsed) {
-        result = localValues.filter((selection) =>
-          this.filteredOptions.every(
-            (option) => option.value !== selection.value
-          )
-        );
+        if (optionsHasGroups) {
+          const allFiltered = getAllOptions(this.filteredOptions);
+          result = localValues.filter((selection) =>
+            allFiltered.every((option) => option.value !== selection.value)
+          );
+        } else {
+          result = localValues.filter((selection) =>
+            this.filteredOptions.every(
+              (option) => option.value !== selection.value
+            )
+          );
+        }
       } else {
         result = [];
       }
     } else {
-      result = getAllOptions(
-        unionBy((item) => item.value, this.filteredOptions, localValues)
-      );
+      result = optionsHasGroups
+        ? getAllOptions(this.filteredOptions)
+        : getAllOptions(
+            unionBy((item) => item.value, this.filteredOptions, localValues)
+          );
     }
 
     this.applyChanges(result);

--- a/src/components/Select/SelectMultiHeader.js
+++ b/src/components/Select/SelectMultiHeader.js
@@ -1,6 +1,7 @@
 import React, { Fragment } from 'react';
 import styled from 'styled-components';
 import * as PropTypes from 'prop-types';
+import { hasGroups } from './select.utils';
 
 // components
 import { Label, Option } from './Select.common';
@@ -14,14 +15,24 @@ const SelectMultiHeader = (props) => {
     return null;
   }
 
-  const filtereValues = values.filter((selected) =>
-    options.some((option) => option.value === selected.value)
-  );
+  const grouped = hasGroups(options);
+  const filtereValues = grouped
+    ? values.filter((selected) =>
+        options.some((option) => {
+          option.options.some((o) => o.value === selected.value);
+        })
+      )
+    : values.filter((selected) =>
+        options.some((option) => option.value === selected.value)
+      );
   const counts = `(${filtereValues.length}/${options.length})`;
   const allSelected = filtereValues.length === options.length;
   const partialSelected =
     filtereValues.length && filtereValues.length < options.length;
-  const isDeselectMode = !!allSelected || !!partialSelected;
+  const anythingSelected = !!allSelected || !!partialSelected;
+  const isDeselectMode = grouped
+    ? !anythingSelected && values.length > 0
+    : anythingSelected;
   const label = isDeselectMode ? 'Deselect all' : 'Select all';
 
   const handleSelect = () => {
@@ -32,7 +43,7 @@ const SelectMultiHeader = (props) => {
     <Fragment>
       <Option className="option" onClick={handleSelect} margin="5px 0 0 0">
         <StyledCheckbox
-          checked={!!allSelected || !!partialSelected}
+          checked={isDeselectMode}
           partial={!!partialSelected}
           className="menu-option-checkbox"
         />


### PR DESCRIPTION
## Description
fix for: multi select with 2 groups crashes when unselecting all. 
filtering the options correctly in multi select when there are groups.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Are you adding a new package?
- [ ] yes
- [x] no
